### PR TITLE
Split up IdentityService into re-usable parts

### DIFF
--- a/kotlin-oauth2-server-core/src/main/java/nl/myndocs/oauth2/authenticator/Authorizer.kt
+++ b/kotlin-oauth2-server-core/src/main/java/nl/myndocs/oauth2/authenticator/Authorizer.kt
@@ -1,0 +1,28 @@
+package nl.myndocs.oauth2.authenticator
+
+
+interface Authorizer<T : Any> {
+    /**
+     * Call to retrieve the credentials from Context
+     * If credentials can not be retrieved from Context return null
+     */
+    fun extractCredentials(context: T): Credentials?
+
+    /**
+     * Callback when authentication have failed
+     */
+    fun failedAuthentication(context: T)
+
+    /**
+     * Override default token authentication if Authenticator != null
+     * This allows different authentication per request
+     */
+    fun authenticator(context: T): Authenticator? = null
+
+    /**
+     * Override default token scope verification if IdentityScopeVerifier != null
+     * This allows scopes verification per request
+     * E.g. could be used to make consent pages
+     */
+    fun scopesVerifier(context: T): IdentityScopeVerifier? = null
+}

--- a/kotlin-oauth2-server-core/src/main/java/nl/myndocs/oauth2/authenticator/IdentityScopeVerifier.kt
+++ b/kotlin-oauth2-server-core/src/main/java/nl/myndocs/oauth2/authenticator/IdentityScopeVerifier.kt
@@ -3,6 +3,6 @@ package nl.myndocs.oauth2.authenticator
 import nl.myndocs.oauth2.client.Client
 import nl.myndocs.oauth2.identity.Identity
 
-interface Authenticator {
-    fun validCredentials(forClient: Client, identity: Identity, password: String): Boolean
+interface IdentityScopeVerifier {
+    fun validScopes(forClient: Client, identity: Identity, scopes: Set<String>): Boolean
 }

--- a/kotlin-oauth2-server-core/src/main/java/nl/myndocs/oauth2/identity/IdentityService.kt
+++ b/kotlin-oauth2-server-core/src/main/java/nl/myndocs/oauth2/identity/IdentityService.kt
@@ -1,15 +1,13 @@
 package nl.myndocs.oauth2.identity
 
+import nl.myndocs.oauth2.authenticator.Authenticator
+import nl.myndocs.oauth2.authenticator.IdentityScopeVerifier
 import nl.myndocs.oauth2.client.Client
 
-interface IdentityService {
+interface IdentityService : Authenticator, IdentityScopeVerifier {
     /**
      * Find identity within a client and username
      * If not found return null
      */
     fun identityOf(forClient: Client, username: String): Identity?
-
-    fun validCredentials(forClient: Client, identity: Identity, password: String): Boolean
-
-    fun validScopes(forClient: Client, identity: Identity, scopes: Set<String>): Boolean
 }

--- a/kotlin-oauth2-server-core/src/test/java/nl/myndocs/oauth2/AuthorizationCodeGrantTokenServiceTest.kt
+++ b/kotlin-oauth2-server-core/src/test/java/nl/myndocs/oauth2/AuthorizationCodeGrantTokenServiceTest.kt
@@ -10,6 +10,7 @@ import nl.myndocs.oauth2.client.ClientService
 import nl.myndocs.oauth2.exception.InvalidClientException
 import nl.myndocs.oauth2.exception.InvalidGrantException
 import nl.myndocs.oauth2.exception.InvalidRequestException
+import nl.myndocs.oauth2.identity.Identity
 import nl.myndocs.oauth2.identity.IdentityService
 import nl.myndocs.oauth2.request.AuthorizationCodeRequest
 import nl.myndocs.oauth2.token.AccessToken
@@ -60,6 +61,7 @@ internal class AuthorizationCodeGrantTokenServiceTest {
         val requestScopes = setOf("scope1")
 
         val client = Client(clientId, setOf("scope1", "scope2"), setOf())
+        val identity = Identity(username)
         val codeToken = CodeToken(code, Instant.now(), username, clientId, redirectUri, requestScopes)
 
         val refreshToken = RefreshToken("test", Instant.now(), username, clientId, requestScopes)
@@ -67,6 +69,7 @@ internal class AuthorizationCodeGrantTokenServiceTest {
 
         every { clientService.clientOf(clientId) } returns client
         every { clientService.validClient(client, clientSecret) } returns true
+        every { identityService.identityOf(client, username) } returns identity
         every { tokenStore.consumeCodeToken(code) } returns codeToken
         every { refreshTokenConverter.convertToToken(username, clientId, requestScopes) } returns refreshToken
         every { accessTokenConverter.convertToToken(username, clientId, requestScopes, refreshToken) } returns accessToken

--- a/kotlin-oauth2-server-core/src/test/java/nl/myndocs/oauth2/PasswordGrantTokenServiceTest.kt
+++ b/kotlin-oauth2-server-core/src/test/java/nl/myndocs/oauth2/PasswordGrantTokenServiceTest.kt
@@ -77,7 +77,6 @@ internal class PasswordGrantTokenServiceTest {
 
         tokenService.authorize(passwordGrantRequest)
 
-
         verify { tokenStore.storeAccessToken(accessToken) }
     }
 

--- a/kotlin-oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
+++ b/kotlin-oauth2-server-core/src/test/java/nl/myndocs/oauth2/RefreshTokenGrantTokenServiceTest.kt
@@ -1,0 +1,131 @@
+package nl.myndocs.oauth2
+
+import io.mockk.every
+import io.mockk.impl.annotations.InjectMockKs
+import io.mockk.impl.annotations.MockK
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.junit5.MockKExtension
+import io.mockk.verify
+import nl.myndocs.oauth2.client.Client
+import nl.myndocs.oauth2.client.ClientService
+import nl.myndocs.oauth2.exception.InvalidClientException
+import nl.myndocs.oauth2.exception.InvalidGrantException
+import nl.myndocs.oauth2.exception.InvalidRequestException
+import nl.myndocs.oauth2.identity.Identity
+import nl.myndocs.oauth2.identity.IdentityService
+import nl.myndocs.oauth2.request.RefreshTokenRequest
+import nl.myndocs.oauth2.token.AccessToken
+import nl.myndocs.oauth2.token.RefreshToken
+import nl.myndocs.oauth2.token.TokenStore
+import nl.myndocs.oauth2.token.converter.AccessTokenConverter
+import nl.myndocs.oauth2.token.converter.CodeTokenConverter
+import nl.myndocs.oauth2.token.converter.RefreshTokenConverter
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import java.time.Instant
+
+@ExtendWith(MockKExtension::class)
+internal class RefreshTokenGrantTokenServiceTest {
+    @MockK
+    lateinit var identityService: IdentityService
+    @MockK
+    lateinit var clientService: ClientService
+    @RelaxedMockK
+    lateinit var tokenStore: TokenStore
+    @MockK
+    lateinit var accessTokenConverter: AccessTokenConverter
+    @MockK
+    lateinit var refreshTokenConverter: RefreshTokenConverter
+    @MockK
+    lateinit var codeTokenConverter: CodeTokenConverter
+
+    @InjectMockKs
+    lateinit var tokenService: TokenService
+
+    val clientId = "client-foo"
+    val clientSecret = "client-bar"
+    val refreshToken = "refresh-token"
+    val username = "foo-user"
+    val scope = "scope1"
+    val scopes = setOf(scope)
+
+    val refreshTokenRequest = RefreshTokenRequest(
+            clientId,
+            clientSecret,
+            refreshToken
+    )
+
+    @Test
+    fun validRefreshToken() {
+        val client = Client(clientId, setOf("scope1", "scope2"), setOf())
+        val token = RefreshToken("test", Instant.now(), username, clientId, scopes)
+        val newRefreshToken = RefreshToken("test", Instant.now(), username, clientId, scopes)
+        val accessToken = AccessToken("test", "bearer", Instant.now(), username, clientId, scopes, newRefreshToken)
+        val identity = Identity(username)
+
+        every { clientService.clientOf(clientId) } returns client
+        every { clientService.validClient(client, clientSecret) } returns true
+        every { tokenStore.refreshToken(refreshToken) } returns token
+        every { identityService.identityOf(client, username) } returns identity
+        every { refreshTokenConverter.convertToToken(username, clientId, scopes) } returns newRefreshToken
+        every { accessTokenConverter.convertToToken(username, clientId, scopes, newRefreshToken) } returns accessToken
+
+        tokenService.refresh(refreshTokenRequest)
+
+
+        verify { tokenStore.storeAccessToken(accessToken) }
+    }
+
+    @Test
+    fun missingRefreshToken() {
+        val client = Client(clientId, setOf("scope1", "scope2"), setOf())
+
+        every { clientService.clientOf(clientId) } returns client
+        every { clientService.validClient(client, clientSecret) } returns true
+
+        val refreshTokenRequest = RefreshTokenRequest(
+                clientId,
+                clientSecret,
+                null
+        )
+
+        Assertions.assertThrows(
+                InvalidRequestException::class.java
+        ) { tokenService.refresh(refreshTokenRequest) }
+    }
+
+    @Test
+    fun nonExistingClientException() {
+        every { clientService.clientOf(clientId) } returns null
+
+        Assertions.assertThrows(
+                InvalidClientException::class.java
+        ) { tokenService.refresh(refreshTokenRequest) }
+    }
+
+    @Test
+    fun invalidClientException() {
+        val client = Client(clientId, setOf(), setOf())
+        every { clientService.clientOf(clientId) } returns client
+        every { clientService.validClient(client, clientSecret) } returns false
+
+        Assertions.assertThrows(
+                InvalidClientException::class.java
+        ) { tokenService.refresh(refreshTokenRequest) }
+    }
+
+    @Test
+    fun storedClientDoesNotMatchRequestedException() {
+        val client = Client(clientId, setOf("scope1", "scope2"), setOf())
+        val token = RefreshToken("test", Instant.now(), username, "wrong-client", scopes)
+
+        every { clientService.clientOf(clientId) } returns client
+        every { clientService.validClient(client, clientSecret) } returns true
+        every { tokenStore.refreshToken(refreshToken) } returns token
+
+        Assertions.assertThrows(
+                InvalidGrantException::class.java
+        ) { tokenService.refresh(refreshTokenRequest) }
+    }
+}

--- a/kotlin-oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/Oauth2Server.kt
+++ b/kotlin-oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/Oauth2Server.kt
@@ -4,7 +4,7 @@ import io.javalin.Context
 import io.javalin.Javalin
 import io.javalin.apibuilder.ApiBuilder.*
 import nl.myndocs.oauth2.TokenService
-import nl.myndocs.oauth2.authenticator.Authenticator
+import nl.myndocs.oauth2.authenticator.Authorizer
 import nl.myndocs.oauth2.client.ClientService
 import nl.myndocs.oauth2.exception.InvalidGrantException
 import nl.myndocs.oauth2.exception.InvalidRequestException
@@ -13,7 +13,7 @@ import nl.myndocs.oauth2.exception.toMap
 import nl.myndocs.oauth2.identity.IdentityService
 import nl.myndocs.oauth2.identity.UserInfo
 import nl.myndocs.oauth2.javalin.routing.*
-import nl.myndocs.oauth2.javalin.util.BasicAuthenticator
+import nl.myndocs.oauth2.javalin.util.BasicAuthorizer
 import nl.myndocs.oauth2.token.TokenStore
 import nl.myndocs.oauth2.token.converter.*
 
@@ -33,7 +33,7 @@ data class OauthConfiguration(
                     "scopes" to userInfo.scopes
             )
         },
-        var authenticator: Authenticator<Context> = BasicAuthenticator
+        var authorizer: Authorizer<Context> = BasicAuthorizer
 )
 
 fun Javalin.enableOauthServer(configurationCallback: OauthConfiguration.() -> Unit) {
@@ -92,8 +92,8 @@ fun Javalin.enableOauthServer(configurationCallback: OauthConfiguration.() -> Un
                             .mapValues { ctx.queryParam(it.key) }
 
                     when (responseType) {
-                        "code" -> routeAuthorizationCodeRedirect(ctx, tokenService, paramMap, configuration.authenticator)
-                        "token" -> routeAccessTokenRedirect(ctx, tokenService, paramMap, configuration.authenticator)
+                        "code" -> routeAuthorizationCodeRedirect(ctx, tokenService, paramMap, configuration.authorizer)
+                        "token" -> routeAccessTokenRedirect(ctx, tokenService, paramMap, configuration.authorizer)
                     }
                 } catch (oauthException: OauthException) {
                     ctx.status(400)

--- a/kotlin-oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/util/BasicAuthorizer.kt
+++ b/kotlin-oauth2-server-javalin/src/main/java/nl/myndocs/oauth2/javalin/util/BasicAuthorizer.kt
@@ -1,12 +1,12 @@
 package nl.myndocs.oauth2.javalin.util
 
 import io.javalin.Context
-import nl.myndocs.oauth2.authenticator.Authenticator
+import nl.myndocs.oauth2.authenticator.Authorizer
 import nl.myndocs.oauth2.authenticator.Credentials
 import nl.myndocs.oauth2.ktor.feature.util.BasicAuth
 
-object BasicAuthenticator : Authenticator<Context> {
-    override fun authenticate(context: Context): Credentials? {
+object BasicAuthorizer : Authorizer<Context> {
+    override fun extractCredentials(context: Context): Credentials? {
         val authorizationHeader = context.header("authorization") ?: ""
         return BasicAuth.parseCredentials(authorizationHeader)
     }

--- a/kotlin-oauth2-server-ktor/src/main/java/nl/myndocs/oauth2/ktor/feature/Oauth2ServerFeature.kt
+++ b/kotlin-oauth2-server-ktor/src/main/java/nl/myndocs/oauth2/ktor/feature/Oauth2ServerFeature.kt
@@ -12,14 +12,14 @@ import io.ktor.request.path
 import io.ktor.response.respond
 import io.ktor.util.AttributeKey
 import nl.myndocs.oauth2.TokenService
-import nl.myndocs.oauth2.authenticator.Authenticator
+import nl.myndocs.oauth2.authenticator.Authorizer
 import nl.myndocs.oauth2.client.ClientService
 import nl.myndocs.oauth2.identity.IdentityService
 import nl.myndocs.oauth2.identity.UserInfo
 import nl.myndocs.oauth2.ktor.feature.json.MapToJson
 import nl.myndocs.oauth2.ktor.feature.routing.authorize.configureAuthorizeEndpoint
 import nl.myndocs.oauth2.ktor.feature.routing.token.configureTokenEndpoint
-import nl.myndocs.oauth2.ktor.feature.util.BasicAuthenticator
+import nl.myndocs.oauth2.ktor.feature.util.BasicAuthorizer
 import nl.myndocs.oauth2.token.TokenStore
 import nl.myndocs.oauth2.token.converter.*
 
@@ -42,7 +42,7 @@ class Oauth2ServerFeature(configuration: Configuration) {
             refreshTokenConverter,
             codeTokenConverter
     )
-    val authenticator: Authenticator<ApplicationCall> = configuration.authenticator
+    val authorizer: Authorizer<ApplicationCall> = configuration.authorizer
 
     class Configuration {
         var tokenEndpoint = "/oauth/token"
@@ -60,7 +60,7 @@ class Oauth2ServerFeature(configuration: Configuration) {
                     "scopes" to userInfo.scopes
             )
         }
-        var authenticator: Authenticator<ApplicationCall> = BasicAuthenticator
+        var authorizer: Authorizer<ApplicationCall> = BasicAuthorizer
     }
 
     companion object Feature : ApplicationFeature<ApplicationCallPipeline, Oauth2ServerFeature.Configuration, Oauth2ServerFeature> {

--- a/kotlin-oauth2-server-ktor/src/main/java/nl/myndocs/oauth2/ktor/feature/util/BasicAuthorizer.kt
+++ b/kotlin-oauth2-server-ktor/src/main/java/nl/myndocs/oauth2/ktor/feature/util/BasicAuthorizer.kt
@@ -3,11 +3,11 @@ package nl.myndocs.oauth2.ktor.feature.util
 import io.ktor.application.ApplicationCall
 import io.ktor.request.header
 import io.ktor.response.header
-import nl.myndocs.oauth2.authenticator.Authenticator
+import nl.myndocs.oauth2.authenticator.Authorizer
 import nl.myndocs.oauth2.authenticator.Credentials
 
-object BasicAuthenticator : Authenticator<ApplicationCall> {
-    override fun authenticate(context: ApplicationCall): Credentials? {
+object BasicAuthorizer : Authorizer<ApplicationCall> {
+    override fun extractCredentials(context: ApplicationCall): Credentials? {
         val authorizationHeader = context.request.header("authorization") ?: ""
         return BasicAuth.parseCredentials(authorizationHeader)
     }


### PR DESCRIPTION
Redirects authentication can be intercepted based on there context